### PR TITLE
modify existing settings functionality to allow for multiple repos

### DIFF
--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -70,14 +70,6 @@ define maven::settings( $home = undef, $user = 'root',
   $servers = [], $mirrors = [], $default_repo_config = undef, $repos = [],
   $properties = {}, $local_repo = '', $proxies=[]) {
 
-  if $default_repo_config == undef {
-    $allrepos = $repos
-  }
-  else {
-    $default_repo_config['id'] = 'central'
-    $allrepos = $repos + $default_repo_config
-  }
-
   if $home == undef {
     $home_real = $user ? {
       'root'  => '/root',

--- a/templates/settings.xml.erb
+++ b/templates/settings.xml.erb
@@ -61,16 +61,22 @@
   </proxies>
 
 <% end -%>
+<% 
+  unless @default_repo_config.nil?
+    @default_repo_config['id'] = 'central'
+    @repos << @default_repo_config
+  end
+-%>
 <% unless @repos.empty? and @properties.empty? -%>
   <profiles>
     <%- unless @repos.empty? -%>
     <profile>
-      <id>default-repos</id>
+      <id>default-repo</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <repositories>
-<% repos.each do |repo| -%>
+<% @repos.each do |repo| -%>
         <repository>
           <id><%= repo['id'] %></id>
 <% unless repo['name'].nil? -%>
@@ -95,7 +101,7 @@
 <% end -%>
       </repositories>
       <pluginRepositories>
-<% repos.each do |repo| -%>
+<% @repos.each do |repo| -%>
         <pluginRepository>
           <id><%= repo['id'] %></id>
 <% unless repo['name'].nil? -%>


### PR DESCRIPTION
This change is not backwards compatible in the sense that I remove the default_repo_config attribute from the settings.pp file in favour of allowing any number of repos to be configured. If this is an issue, I would be happy to re-add this variable so that both can co-exist. But I thought this approach was cleaner.

Open to suggestions.
