### PR TITLE
Create the symlink inside the if

### DIFF
--- a/manifests/maven.pp
+++ b/manifests/maven.pp
@@ -64,14 +64,14 @@ class maven::maven(
       creates => "/opt/apache-maven-${version}",
       path    => ['/bin','/usr/bin'],
     }
-  }
 
-  file { '/usr/bin/mvn':
-    ensure => link,
-    target => "/opt/apache-maven-${version}/bin/mvn",
-    require => Exec['maven-untar'],
-  } ->
-  file { '/usr/local/bin/mvn':
-    ensure  => absent,
+    file { '/usr/bin/mvn':
+      ensure  => link,
+      target  => "/opt/apache-maven-${version}/bin/mvn",
+      require => Exec['maven-untar'],
+    } ->
+    file { '/usr/local/bin/mvn':
+      ensure  => absent,
+    }
   }
 }


### PR DESCRIPTION
The problem having it outside of the if is that the untar resource
doesn't exist if maven is already installed. I justify moving it inside
becasue if the symlink doesn't exist, then it is likely that
$::maven_version will not be the same as $version, and will install the
version specified, thus creating the new symlink.
