### PR TITLE
Allow ssh privateKey in server settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Examples
   # Create a settings.xml with the repo credentials
   maven::settings { 'maven-user-settings' :
     mirrors => [$central], # mirrors entry in settings.xml, uses id, url, mirrorof from the hash passed
-    servers => [$central], # servers entry in settings.xml, uses id, username, password from the hash passed
+    servers => [$central], # servers entry in settings.xml, uses id, username, password from the hash passed, privateKey
     proxies => [$proxy], # proxies entry in settings.xml, active, protocol, host, username, password, nonProxyHosts
     user    => 'maven',
   }

--- a/spec/defines/complete-settings.xml
+++ b/spec/defines/complete-settings.xml
@@ -22,6 +22,11 @@
       <username>deploy_user</username>
       <password>deploy_pass</password>
     </server>
+    <server>
+      <id>maestro-deploy-ssh</id>
+      <username>deploy_ssh_user</username>
+      <privateKey>~/.ssh/id_rsa</privateKey>
+    </server>
   </servers>
 
   <profiles>

--- a/spec/defines/mirror-servers-settings.xml
+++ b/spec/defines/mirror-servers-settings.xml
@@ -20,6 +20,11 @@
       <username>deploy_user</username>
       <password>deploy_pass</password>
     </server>
+    <server>
+      <id>maestro-deploy-ssh</id>
+      <username>deploy_ssh_user</username>
+      <privateKey>~/.ssh/id_rsa</privateKey>
+    </server>
   </servers>
 
 </settings>

--- a/spec/defines/settings_spec.rb
+++ b/spec/defines/settings_spec.rb
@@ -36,6 +36,11 @@ describe "maven::settings" do
     'username' => 'deploy_user',
     'password' => 'deploy_pass',
   }}
+  let(:deploy_server_with_ssh) {{
+    'id' => 'maestro-deploy-ssh',
+    'username' => 'deploy_ssh_user',
+    'privateKey' => '~/.ssh/id_rsa',
+  }}
   let(:default_repo_config) {{
     'url' => url,
     'snapshots' => {
@@ -84,7 +89,7 @@ describe "maven::settings" do
           :user => "u",
           :home => "/home/u",
           :mirrors => [mirror],
-          :servers => [mirror_server, deploy_server]
+          :servers => [mirror_server, deploy_server, deploy_server_with_ssh]
       }}
 
     it_behaves_like :maven_settings, "mirror-servers-settings.xml"
@@ -147,7 +152,7 @@ describe "maven::settings" do
           :user => "u",
           :home => "/home/u",
           :mirrors => [mirror],
-          :servers => [mirror_server, deploy_server],
+          :servers => [mirror_server, deploy_server, deploy_server_with_ssh],
           :default_repo_config => default_repo_config,
           :properties => properties,
           :local_repo => "/var/cache/maven/repository",

--- a/templates/settings.xml.erb
+++ b/templates/settings.xml.erb
@@ -22,8 +22,14 @@
 <% @servers.each do |server| -%>
     <server>
       <id><%= server['id'] %></id>
+<% ['username', 'password','privateKey' ] -%>
       <username><%= server['username'] %></username>
+<% unless server['password'].nil? -%>
       <password><%= server['password'] %></password>
+<% end -%>
+<% unless server['privateKey'].nil? -%>
+      <privateKey><%= server['privateKey'] %></privateKey>
+<% end -%>
     </server>
 <% end -%>
   </servers>


### PR DESCRIPTION
Hi,

thanks for your great module.
This pull requests allows to set a servers privateKey for Key-Based ssh deployments.
(Compare https://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-ssh-external.html)

Thanks,
Arnd