### PR TITLE
Fixed possible cyclic dep when used with other modules

### DIFF
--- a/manifests/maven.pp
+++ b/manifests/maven.pp
@@ -58,6 +58,13 @@ class maven::maven(
         before      => Exec['maven-untar'],
       }
     }
+
+    if ! defined(File['/opt']) {
+      file { '/opt':
+        ensure  => directory,
+      }
+    }
+
     exec { 'maven-untar':
       command => "tar xf /tmp/apache-maven-${version}-bin.tar.gz",
       cwd     => '/opt',


### PR DESCRIPTION
"cwd     => '/opt'"  implies that /opt should exist, so there should be an explicit file {'opt':}. This fixed some cyclic dep hell for me.