### PR TITLE
Run maven in batch mode to prevent log spam

### DIFF
--- a/lib/puppet/provider/maven/mvn.rb
+++ b/lib/puppet/provider/maven/mvn.rb
@@ -122,7 +122,7 @@ Puppet::Type.type(:maven).provide(:mvn) do
       debug "mvn downloading (if needed) repo file #{msg} to #{dest} from #{repos.join(', ')}"
     end
 
-    command = ["mvn org.apache.maven.plugins:maven-dependency-plugin:#{plugin_version}:get #{command_string} -DremoteRepositories=#{repos.join(',')} -Ddest=#{dest} -Dtransitive=false -Ppuppet-maven #{options}"]
+    command = ["mvn -B org.apache.maven.plugins:maven-dependency-plugin:#{plugin_version}:get #{command_string} -DremoteRepositories=#{repos.join(',')} -Ddest=#{dest} -Dtransitive=false -Ppuppet-maven #{options}"]
 
     timeout = @resource[:timeout].nil? ? 0 : @resource[:timeout].to_i
     output = nil

--- a/spec/unit/puppet/provider/maven/mvn_spec.rb
+++ b/spec/unit/puppet/provider/maven/mvn_spec.rb
@@ -259,7 +259,7 @@ describe provider_class do
           end
 
           it 'should default to plugin version 2.4' do
-            should match /mvn org\.apache\.maven\.plugins:maven-dependency-plugin:2\.4:get/
+            should match /mvn -B org\.apache\.maven\.plugins:maven-dependency-plugin:2\.4:get/
           end
 
           it 'should pass no repoId' do
@@ -400,7 +400,7 @@ describe provider_class do
             let(:params) { { pluginversion: '2.5' } }
 
             it 'should pass provided version' do
-              should match /mvn org\.apache\.maven\.plugins:maven-dependency-plugin:2\.5:get/
+              should match /mvn -B org\.apache\.maven\.plugins:maven-dependency-plugin:2\.5:get/
             end
           end
 


### PR DESCRIPTION
Maven is run in interactive mode, which means when downloading a large artifact, maven will print out how far through the download it is (e.g. `172Kb/1651Kb`) and constantly updates this value in the console. The maven output appears in the puppet output if `--debug` is used. However, this means if capturing the logs of a puppet apply, you may have many many lines of output from maven just keeping its xKb/yKb updated.

This PR sets maven to batch mode, to stop it printing out these kind of logs.