### PR TITLE
-- #60: adding support for the Maven security file

### DIFF
--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -128,10 +128,10 @@
 #
 # activeProfiles => [ 'profile1', 'profile2', ...]
 #
-define maven::settings( $home = undef, $user = 'root', $group = 'root',
+define maven::settings($home = undef, $user = 'root', $group = 'root',
   $servers = [], $mirrors = [], $default_repo_config = undef, $repos = [],
   $properties = {}, $local_repo = '', $dir_mask = '700', $file_mask = '600',
-  $proxies = [], $profiles = {}, $active_profiles = []) {
+  $proxies = [], $profiles = {}, $active_profiles = [], $master_password = undef) {
 
   if $home == undef {
     $home_real = $user ? {
@@ -156,4 +156,13 @@ define maven::settings( $home = undef, $user = 'root', $group = 'root',
     content => template('maven/settings.xml.erb'),
   }
 
+  unless $master_password == undef {
+    file { "${home_real}/.m2/settings-security.xml":
+      owner   => $user,
+      group   => $group,
+      mode    => $file_mask,
+      content => template('maven/settings-security.xml.erb'),
+      require => File["${home_real}/.m2"],
+    }
+  }
 }

--- a/spec/defines/default-settings-security.xml
+++ b/spec/defines/default-settings-security.xml
@@ -1,0 +1,3 @@
+<settingsSecurity>
+  <master>{7837*#&$*i878283mkjdksf=}</master>
+</settingsSecurity>

--- a/spec/defines/settings_spec.rb
+++ b/spec/defines/settings_spec.rb
@@ -13,6 +13,19 @@ shared_examples :maven_settings do |expected_file|
   end
 end
 
+shared_examples :maven_settings_security do |expected_file|
+
+  def read_file(filename)
+    IO.read(File.expand_path(filename, File.dirname(__FILE__)))
+  end
+
+  it { should contain_file(expected_filename).with_owner('u') }
+
+  it 'should generate valid settings.xml' do
+    should contain_file(expected_filename).with_content(read_file(expected_file))
+  end
+end
+
 describe "maven::settings" do
   let(:title) { 'settings' }
   let(:params) { {
@@ -243,5 +256,16 @@ describe "maven::settings" do
       }}
 
     it_behaves_like :maven_settings, "active-profiles-settings.xml"
+  end
+
+  context "with master password", :compile do
+    let(:expected_filename) { '/home/u/.m2/settings-security.xml' }
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :master_password => '{7837*#&$*i878283mkjdksf=}'
+      }}
+
+    it_behaves_like :maven_settings_security, "default-settings-security.xml"
   end
 end

--- a/templates/settings-security.xml.erb
+++ b/templates/settings-security.xml.erb
@@ -1,0 +1,3 @@
+<settingsSecurity>
+  <master><%= @master_password %></master>
+</settingsSecurity>


### PR DESCRIPTION
This adds support for creating/managing the 'settings-security.xml' file used to encrypt passwords for maven.