### PR TITLE
Changed from repository to pluginRepository.

### DIFF
--- a/spec/defines/profiles-settings.xml
+++ b/spec/defines/profiles-settings.xml
@@ -41,7 +41,7 @@
         </repository>
       </repositories>
       <pluginRepositories>
-        <repository>
+        <pluginRepository>
           <id>repo2</id>
           <name>Second Repo</name>
           <releases>
@@ -56,7 +56,7 @@
           </snapshots>
           <url>http://repo2.example.com/maven2</url>
           <layout>legacy</layout>
-        </repository>
+        </pluginRepository>
       </pluginRepositories>
       <properties>
         <key1>value1</key1>

--- a/templates/settings.xml.erb
+++ b/templates/settings.xml.erb
@@ -227,7 +227,7 @@
       <%- unless (profile['pluginRepositories']||[]).empty?; repositories = profile['pluginRepositories'] -%>
       <pluginRepositories>
         <%- repositories.each do |repo_id, repo| -%>
-        <repository>
+        <pluginRepository>
           <id><%= repo_id %></id>
           <%- if repo['name'] -%>
           <name><%= repo['name'] %></name>
@@ -252,7 +252,7 @@
           <%- if repo['layout'] -%>
           <layout><%= repo['layout'] %></layout>
           <%- end -%>
-        </repository>
+        </pluginRepository>
         <%- end -%>
       </pluginRepositories>
       <%- end -%>


### PR DESCRIPTION
When using the plugin with maven plugin repositories, I noticed that the resulting settings.xml contained the child element <repository> instead of <pluginRepository>. It is a minor issue that I believe I have fixed and I am hoping it could make it into the next official release?