### PR TITLE
Adding email to puppet maven configuration

### DIFF
--- a/templates/settings.xml.erb
+++ b/templates/settings.xml.erb
@@ -30,6 +30,11 @@
 <% unless server['privateKey'].nil? -%>
       <privateKey><%= server['privateKey'] %></privateKey>
 <% end -%>
+<% unless server['configuration'].nil? -%>
+<% unless server['configuration']['email'].nil? -%>
+      <configuration><email><%= server['configuration']['email'] %></email></configuration>
+<% end -%>
+<% end -%>
     </server>
 <% end -%>
   </servers>


### PR DESCRIPTION
Using a maven-docker plugin (https://github.com/spotify/docker-maven-plugin) requires passing email in <server/> tag in settings.xml, otherwise authentication fails, despite giving correct username/password.